### PR TITLE
Choose to force trailing slash—or not

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var parseURL = require('url').parse;
 
-module.exports = function (statusCode) {
+module.exports = function (statusCode, forceNoSlash) {
     statusCode || (statusCode = 301);
+    forceNoSlash || (forceNoSlash = false);
 
     return function (req, res, next) {
         var routes = req.app.routes[req.method.toLowerCase()],
-            url, pathname, search, match;
+            url, pathname, search, match, correctPath;
 
         // Skip when no routes for the request method.
         if (!routes) {
@@ -13,23 +14,27 @@ module.exports = function (statusCode) {
             return;
         }
 
-        url      = parseURL(req.url);
-        pathname = url.pathname;
-        search   = url.search || '';
+        url         = parseURL(req.url);
+        pathname    = url.pathname;
+        search      = url.search || '';
+        correctPath = (forceNoSlash) ? pathname.slice(0, -1) : pathname + '/'
 
-        // Skip when the path already has a trailing slash.
-        if (pathname.charAt(pathname.length - 1) === '/') {
+        // Skip when the path already has the correct slash
+        if (
+            (!forceNoSlash && pathname.charAt(pathname.length - 1) === '/')
+            || (forceNoSlash && pathname.charAt(pathname.length - 1) !== '/')
+        ) {
             next();
             return;
         }
 
         // Look for matching route.
         match = routes.some(function (r) {
-            return r.match(pathname + '/');
+            return r.match(correctPath);
         });
 
         if (match) {
-            res.redirect(statusCode, pathname + '/' + search);
+            res.redirect(statusCode, correctPath + search);
         } else {
             next();
         }


### PR DESCRIPTION
I wanted the ability to force no trailing slash instead of forcing a trailing slash.

There is now a second argument for choosing to have a slash or not, like:

``` js
// Force no trailing slash
app.use(slash(301, false));
```
