### PR TITLE
Automatically determine whether to test with or without a trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var parseURL = require('url').parse;
 
 module.exports = function (statusCode) {
+    // Force a permanent redirect, unless otherwise specified.
     statusCode || (statusCode = 301);
 
     return function (req, res, next) {
@@ -24,20 +25,18 @@ module.exports = function (statusCode) {
         url      = parseURL(req.url);
         pathname = url.pathname;
         search   = url.search || '';
+        hasSlash = pathname.charAt(pathname.length - 1) === '/';
 
-        // Skip when the path already has a trailing slash.
-        if (pathname.charAt(pathname.length - 1) === '/') {
-            next();
-            return;
-        }
+        // Adjust the URL's path by either adding or removing a trailing slash.
+        pathname = hasSlash ? pathname.slice(0, -1) : (pathname + '/');
 
         // Look for matching route.
         match = routes.some(function (r) {
-            return r.match(pathname + '/');
+            return r.match(pathname);
         });
 
         if (match) {
-            res.redirect(statusCode, pathname + '/' + search);
+            res.redirect(statusCode, pathname + search);
         } else {
             next();
         }

--- a/index.js
+++ b/index.js
@@ -4,8 +4,16 @@ module.exports = function (statusCode) {
     statusCode || (statusCode = 301);
 
     return function (req, res, next) {
-        var routes = req.app.routes[req.method.toLowerCase()],
-            url, pathname, search, match;
+        var method = req.method.toLowerCase(),
+            hasSlash, match, pathname, routes, slash, url;
+
+        // Skip when the request is neither a GET or HEAD.
+        if (!(method === 'get' || method === 'head')) {
+            next();
+            return;
+        }
+
+        routes = req.app.routes[method];
 
         // Skip when no routes for the request method.
         if (!routes) {


### PR DESCRIPTION
This changes the behavior of this module to be smarter about whether it should test the new URL path with or without a trailing slash. Since this middleware should come after `app.router`, we already know that the URL path as is does not have a matching route. If that original path contains a slash, then it should be remove and visa versa. This new URL path can then be checked against the app's routes to determine if there is a match.

Closes #1 
